### PR TITLE
Fixed missing permission on entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ RUN mkdir -p out
 # Install heif-convert
 RUN pip3 install .
 
+RUN chmod +x entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
The entrypoint.sh script does not have executable permission, therefore the container can not start.

Probably broke at some update.