### PR TITLE
Fix wildcard expansion on Windows

### DIFF
--- a/.github/workflows/test-heif-convert.yml
+++ b/.github/workflows/test-heif-convert.yml
@@ -3,15 +3,28 @@ name: Test heif-convert
 on: [push, pull_request]
 
 jobs:
-  test-script:
-    name: Test Script
-    runs-on: ubuntu-latest
+  test-script-unix:
+    name: Test Script Unix
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install sha256sum on macos
+        if: runner.os == 'macOS'
+        run: brew install coreutils
+
       - name: Install heif-convert
-        run: pip3 install .
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip3 install .
+          echo PATH=$PATH >> $GITHUB_ENV
 
       - name: Add executable permission to test-script
         working-directory: tests
@@ -21,9 +34,24 @@ jobs:
         working-directory: tests
         run: ./test-script.sh
 
+  test-script-windows:
+    name: Test Script Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install heif-convert
+        run: pip3 install .
+
+      - name: Run Test
+        working-directory: tests
+        run: .\test-script.ps1
+
   test-docker-image:
     name: Test Docker Image
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/heif_convert/__main__.py
+++ b/heif_convert/__main__.py
@@ -1,6 +1,8 @@
 import argparse
+from glob import glob
 import os
 import logging
+
 from heif_convert._version import __version__
 
 from PIL import Image
@@ -76,9 +78,14 @@ def parse_args():
 
     args = parser.parse_args()
 
+    expanded_input_files = []
     for input_file in args.input:
+        expanded_input_files.extend(glob(input_file))
+    for input_file in expanded_input_files:
         if not os.path.isfile(input_file):
             parser.error(f"Input file '{input_file}' does not exist")
+
+    args.input = expanded_input_files
 
     return args
 

--- a/tests/test-script.ps1
+++ b/tests/test-script.ps1
@@ -1,0 +1,30 @@
+heif-convert image.heic -f jpg -q 90
+heif-convert *.heic -f jpg -q 90 -o image-wildcard
+heif-convert image.heic -f png
+
+$status_code = 0
+
+$expected_jpg_hash = "3fb5fff1c6bb5f0f5d76d9839f82564d857e81f71e748da1ec480affde10fa8e"
+$expected_png_hash = "f6e29566f59bcce7d0486c9745602354cd903da0dbfce3facb8bba476abeee54"
+
+$actual_jpg_hash = (Get-FileHash -Algorithm SHA256 image.jpg).Hash
+$actual_jpg_wildcard_hash = (Get-FileHash -Algorithm SHA256 image-wildcard.jpg).Hash
+
+if ($expected_jpg_hash -ne $actual_jpg_hash) {
+    Write-Host "JPG image hash differs from expected. Expected: $expected_jpg_hash, Actual: $actual_jpg_hash"
+    $status_code = 1
+}
+
+if ($expected_jpg_hash -ne $actual_jpg_wildcard_hash) {
+    Write-Host "JPG wildcard image hash differs from expected. Expected: $expected_jpg_hash, Actual: $actual_jpg_wildcard_hash"
+    $status_code = 1
+}
+
+$actual_png_hash = (Get-FileHash -Algorithm SHA256 image.png).Hash
+
+if ($expected_png_hash -ne $actual_png_hash) {
+    Write-Host "PNG image hash differs from expected. Expected: $expected_png_hash, Actual: $actual_png_hash"
+    $status_code = 1
+}
+
+exit $status_code

--- a/tests/test-script.sh
+++ b/tests/test-script.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
 heif-convert image.heic -f jpg -q 90
+heif-convert *.heic -f jpg -q 90 -o image-wildcard
 heif-convert image.heic -f png
 
 status_code=0
 
 expected_jpg_hash="3fb5fff1c6bb5f0f5d76d9839f82564d857e81f71e748da1ec480affde10fa8e"
 actual_jpg_hash=$(sha256sum image.jpg | awk '{print $1}')
+actual_jpg_wildcard_hash=$(sha256sum image.jpg | awk '{print $1}')
 
 if [ "$expected_jpg_hash" != "$actual_jpg_hash" ]; then
   echo "JPG image hash differs from expected. Expected: ${expected_jpg_hash}, Actual: ${actual_jpg_hash}"
+  status_code=1
+fi
+
+if [ "$expected_jpg_hash" != "$actual_jpg_wildcard_hash" ]; then
+  echo "JPG wildcard image hash differs from expected. Expected: ${expected_jpg_hash}, Actual: ${actual_jpg_wildcard_hash}"
   status_code=1
 fi
 


### PR DESCRIPTION
Unlike Unix-like systems, Windows does not automatically expand wildcards in the command line. This resulted in `heif-convert *.heic` not working correctly on Windows environments.

This pull request fixes #24 and adds some tests to avoid regressions